### PR TITLE
Ajuste na validação IE Alagoas

### DIFF
--- a/DocsBr/Validation/IE/IEAlagoasValidator.cs
+++ b/DocsBr/Validation/IE/IEAlagoasValidator.cs
@@ -29,17 +29,23 @@ namespace DocsBr.Validation.IE
              *  7- Micro-Empresa Ambulante, 
              *  8-Micro-Empresa)
              */
+             
+            /* 
+            Desabilitado pois existe IEs válidas que não se enquadram nessa regra.
+            
             string[] validTypes = {"0", "3", "5", "7", "8"};
             string number = this.inscEstadual.Substring(2, 1);
             return validTypes.Contains(number);
+            */
+            
+            return true;
         }
 
         private bool HasValidCheckDigits()
         {
             string number = this.inscEstadual.Substring(0, this.inscEstadual.Length - 1);
 
-            DigitoVerificador digitoVerificador = new DigitoVerificador(number)
-                                                    .Substituindo("0", 10, 11);
+            DigitoVerificador digitoVerificador = new DigitoVerificador(number).Substituindo("0", 10, 11);
             return digitoVerificador.CalculaDigito() == this.inscEstadual.Substring(this.inscEstadual.Length - 1, 1);
         }
     }


### PR DESCRIPTION
Removida a verificação do 'Tipo da Empresa' na validação do IE de Alagoas pois existem empresas que não se enquadram na regra imposta no código.